### PR TITLE
Add checksums to datastream endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,6 +477,8 @@ version of the data stream, these values are limited to a subset described here.
 | controlGroup  | The datastream's control group, either X, M, E, R
 | versionable   | A boolean value if the datastream is versionable
 | created       | Created date of the datastream, yyyy-MM-ddTHH:mm:ssZ
+| checksumType  | The checksum type, e.g., SHA-1, MD5. Value is "DISABLED" is checksums are not enabled for the datastream.
+| checksum      | The checksum value. Value is "none" if no checksum is available.
 | versions      | Any array of objects each describing each datastream version not including the latest, contains a subset of the fields described here.
 
 #### Example Response
@@ -489,6 +491,8 @@ version of the data stream, these values are limited to a subset described here.
   "mimeType": "application\/rdf+xml",
   "controlGroup": "X",
   "created": "2013-06-23T07:28:32.787Z",
+  "checksumType": "SHA-1",
+  "checksum": "46dbb3122dc1a140a5f344934251d7c1f680ff28",
   "versionable": true,
   "versions": [{
     "label": "Old Label.",

--- a/README.md
+++ b/README.md
@@ -530,6 +530,7 @@ Accept: application/json
 | label         | The new datastream's label (optional)
 | state         | The new datastream’s state, either “A”, “I”, “D” (optional) Defaults to “A”
 | mimeType      | The new datastream’s MIME Type (optional) if not provided then it is guessed from the uploaded file.
+| checksumType  | The new datastream’s checksum type (optional), e.g.,  SHA-1, MD5. Defaults to 'DISABLED'.
 | controlGroup  | The new datastream's control group, either X, M, E, R
 | versionable   | A boolean value if the datastream is versionable (optional) Defaults to true
 | multipart file as request content | File to use as the datastream’s content
@@ -564,6 +565,7 @@ Content-Type: application/json
 | label         | The datastream's new label (optional)
 | state         | The datastream’s new state, either “A”, “I”, “D” (optional)
 | mimeType      | The new datastream’s MIME Type (optional) if not provided then it is guessed from the uploaded file.
+| checksumType  | The datastream’s checksum type (optional), e.g.,  SHA-1, MD5. Defaults to 'DISABLED'.
 | versionable   | A boolean value if the datastream is versionable (optional) Defaults to true
 | multipart file as request content | File to replace existing datastream (for Managed datastreams)
 
@@ -629,7 +631,7 @@ TODO
 - [ ] Move DC transform logic out of XML Forms and have it use ingested/modified
       hooks instead.
 - [ ] Add support for purging previous versions of datastreams
-- [ ] Add checksum support to datastream end-points.
+- [x] Add checksum support to datastream end-points.
 - [ ] Add describe json end-point for the repository.
 - [ ] Make PUT requests support multi-part form data, populate $_FILES.
 - [ ] Investigate a making a jQuery plugin to ease interaction with REST API?

--- a/README.md
+++ b/README.md
@@ -477,7 +477,7 @@ version of the data stream, these values are limited to a subset described here.
 | controlGroup  | The datastream's control group, either X, M, E, R
 | versionable   | A boolean value if the datastream is versionable
 | created       | Created date of the datastream, yyyy-MM-ddTHH:mm:ssZ
-| checksumType  | The checksum type, e.g., SHA-1, MD5. Value is "DISABLED" is checksums are not enabled for the datastream.
+| checksumType  | The checksum type, e.g., SHA-1, MD5. Value is "DISABLED" if checksums are not enabled for the datastream.
 | checksum      | The checksum value. Value is "none" if no checksum is available.
 | versions      | Any array of objects each describing each datastream version not including the latest, contains a subset of the fields described here.
 

--- a/includes/datastream.inc
+++ b/includes/datastream.inc
@@ -219,6 +219,8 @@ function islandora_rest_get_datastream_properties(AbstractDatastream $datastream
     'controlGroup' => $datastream->controlGroup,
     'created' => (string) $datastream->createdDate,
     'versionable' => (bool) $datastream->versionable,
+    'checksum' => $datastream->checksum,
+    'checksumType' => $datastream->checksumType,
     'versions' => $versions,
   );
 }
@@ -240,5 +242,7 @@ function islandora_rest_get_datastream_version_properties(AbstractDatastream $da
     'mimeType' => $datastream->mimetype,
     'controlGroup' => $datastream->controlGroup,
     'created' => (string) $datastream->createdDate,
+    'checksum' => $datastream->checksum,
+    'checksumType' => $datastream->checksumType,
   );
 }

--- a/includes/datastream.inc
+++ b/includes/datastream.inc
@@ -143,7 +143,7 @@ function islandora_rest_datastream_post_response(array $parameters) {
   $datastream->label = isset($request['label']) ? $request['label'] : $file['name'];
   $datastream->versionable = isset($request['versionable']) ? (bool) $request['versionable'] : TRUE;
   $datastream->mimetype = isset($request['mimeType']) ? $request['mimeType'] : $mime_detect->getMimetype($file['name']);
-  $datastream->checksumType = isset($request['checksumType']) ? $request['checksumType'] : 'DISABLED';
+  $datastream->checksumType = isset($request['checksumType']) ? $request['checksumType'] : variable_get('islandora_checksum_checksum_type', 'DISABLED');
   $datastream->setContentFromFile($file['tmp_name']);
   if (!$object->ingestDatastream($datastream)) {
     throw new Exception('Conflict: Datastream already exists', 409);

--- a/includes/datastream.inc
+++ b/includes/datastream.inc
@@ -67,6 +67,7 @@ function islandora_rest_datastream_get_response(array $parameters) {
  *     - label: The datastream's label.
  *     - state: The datastream's state.
  *     - mimeType: The datastream's MIME Type.
+ *     - checksumType: The datastream's checksum type.
  *     - versionable: Turn versioning on/off.
  */
 function islandora_rest_datastream_put_response(array $parameters) {
@@ -92,6 +93,9 @@ function islandora_rest_datastream_put_response(array $parameters) {
   if (isset($request['mimeType'])) {
     $datastream->mimetype = $request['mimeType'];
   }
+  if (isset($request['checksumType'])) {
+    $datastream->checksumType = $request['checksumType'];
+  }
   // Mock the Get Response.
   return islandora_rest_datastream_get_response(array(
       'resource' => $datastream,
@@ -116,6 +120,7 @@ function islandora_rest_datastream_put_response(array $parameters) {
  *     - state: The new datastream's state (optional).
  *     - mimeType: The new datastream's MIME Type, the MIME Type of the uploaded
  *       file will be used if not provided (optional).
+ *     - checksumType: The new datastream's checksum type (optional).
  *     - versionable: If the datastream will be versionable, defaults to TRUE
  *       (optional).
  *
@@ -138,6 +143,7 @@ function islandora_rest_datastream_post_response(array $parameters) {
   $datastream->label = isset($request['label']) ? $request['label'] : $file['name'];
   $datastream->versionable = isset($request['versionable']) ? (bool) $request['versionable'] : TRUE;
   $datastream->mimetype = isset($request['mimeType']) ? $request['mimeType'] : $mime_detect->getMimetype($file['name']);
+  $datastream->checksumType = isset($request['checksumType']) ? $request['checksumType'] : 'DISABLED';
   $datastream->setContentFromFile($file['tmp_name']);
   if (!$object->ingestDatastream($datastream)) {
     throw new Exception('Conflict: Datastream already exists', 409);

--- a/tests/islandora_rest.test
+++ b/tests/islandora_rest.test
@@ -113,6 +113,8 @@ class IslandoraRestTestCase extends IslandoraHttpRestTestCase {
           'mimeType' => $version->mimetype,
           'controlGroup' => $version->controlGroup,
           'created' => (string) $version->createdDate,
+          'checksumType' => $version->checksumType,
+          'checksum' => $version->checksum,
         );
       }
       $datastreams[] = array(
@@ -124,6 +126,8 @@ class IslandoraRestTestCase extends IslandoraHttpRestTestCase {
         'controlGroup' => $datastream->controlGroup,
         'created' => (string) $datastream->createdDate,
         'versionable' => $datastream->versionable,
+        'checksumType' => $datastream->checksumType,
+        'checksum' => $datastream->checksum,
         'versions' => $versions,
       );
     }
@@ -174,6 +178,8 @@ class IslandoraRestTestCase extends IslandoraHttpRestTestCase {
           'mimeType' => $version->mimetype,
           'controlGroup' => $version->controlGroup,
           'created' => (string) $version->createdDate,
+          'checksumType' => $version->checksumType,
+          'checksum' => $version->checksum,
         );
       }
       return array(
@@ -185,6 +191,8 @@ class IslandoraRestTestCase extends IslandoraHttpRestTestCase {
         'controlGroup' => $datastream->controlGroup,
         'created' => (string) $datastream->createdDate,
         'versionable' => $datastream->versionable,
+        'checksumType' => $datastream->checksumType,
+        'checksum' => $datastream->checksum,
         'versions' => $versions,
       );
     }
@@ -199,6 +207,8 @@ class IslandoraRestTestCase extends IslandoraHttpRestTestCase {
             'mimeType' => $version->mimetype,
             'controlGroup' => $version->controlGroup,
             'created' => (string) $version->createdDate,
+            'checksumType' => $version->checksumType,
+            'checksum' => $version->checksum,
           );
         }
       }


### PR DESCRIPTION
This PR adds support for:

Creating a new datastream with checksums enabled:

`curl -b cookies.txt -v -X POST -H "Content-Type: multipart/form-data"  -F "dsid=FOO" -F "mimeType=text/plain" -F "checksumType=SHA-1" -F "controlGroup=M" -F "file=@foo.txt" "http://localhost:8000/islandora/rest/v1/object/islandora:100/datastream"`

Getting a datastream's checksum:

`curl -v "http://localhost:8000/islandora/rest/v1/object/islandora:100/datastream/FOO?content=false"`

Changing a datastream's checksum properties:

`curl -b cookies.txt -v -X PUT -H "Accept: application/json" -d '{"checksumType":"MD5"}' "http://localhost:8000/islandora/rest/v1/object/islandora:100/datastream/FOO"`

Relevant parts of README.md also updated.
