### PR TITLE
Fix up documentation on islandora_rest_relationship_post_response() '…

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,8 +408,7 @@ Accept: application/json
 | uri           | The predicate URI for the given predicate
 | predicate     | The predicate of the relationship.
 | object        | Object of the relationship.
-| literal       | True if the object of the relationship is a literal, false if it is a URI
-| datatype      | If the object is a literal, the datatype of the literal (optional)
+| type          | The type of the object. Can be either, 'uri', 'string', 'int', 'date', 'none'.
 
 #### Response: 201 Created
 ##### No response body.

--- a/README.md
+++ b/README.md
@@ -405,10 +405,10 @@ Accept: application/json
 #### Post (form-data)
 | Name          | Description                                                  |
 | ------------- | ------------------------------------------------------------ |
-| uri           | The predicate URI for the given predicate
+| uri           | The predicate URI for the given predicate.
 | predicate     | The predicate of the relationship.
 | object        | Object of the relationship.
-| type          | The type of the object. Can be either, 'uri', 'string', 'int', 'date', 'none'.
+| type          | The type of the relationship object. Can be either 'uri', 'string', 'int', 'date', 'none'. Defaults to 'uri'.
 
 #### Response: 201 Created
 ##### No response body.

--- a/includes/relationship.inc
+++ b/includes/relationship.inc
@@ -53,13 +53,14 @@ function islandora_rest_relationship_get_response(array $parameters) {
  *     - predicate: The predicate of the relationship.
  *     - object: Object of the relationship.
  *     - type: The type of the object. This is expressed as a string it can be
- *       either, 'uri', 'string', 'int', 'date', or 'none'.
+ *       either, 'uri', 'string', 'int', 'date', or 'none'. Defaults to 'uri'.
  */
 function islandora_rest_relationship_post_response(array $parameters) {
   $request = $parameters['request'];
-  $required = array('uri', 'predicate', 'object', 'type');
+  $required = array('uri', 'predicate', 'object');
   islandora_rest_require_parameters($request, $required);
-  $type = islandora_rest_relationship_get_datatype($request['type']);
+  $request_type = isset($request['type']) ? $request['type'] : NULL;
+  $type = islandora_rest_relationship_get_datatype($request_type);
   $parameters['resource']->relationships->add($request['uri'], $request['predicate'], $request['object'], $type);
   drupal_add_http_header('Status', 201);
 }

--- a/includes/relationship.inc
+++ b/includes/relationship.inc
@@ -49,12 +49,11 @@ function islandora_rest_relationship_get_response(array $parameters) {
  *   An associative array containing relevent data for this request.
  *   - resource: The object that will own the new relationship.
  *   - request: The request parameters
- *     - uri: The predicate URI for the given predicate
+ *     - uri: The predicate URI for the given predicate.
  *     - predicate: The predicate of the relationship.
  *     - object: Object of the relationship.
- *     - type: The type of the object. This is expressed as an string it can be
- *       either, 'uri', 'string', 'int', 'date', 'none'. (optional)
- *       Defaults to 'uri'.
+ *     - type: The type of the object. This is expressed as a string it can be
+ *       either, 'uri', 'string', 'int', 'date', or 'none'.
  */
 function islandora_rest_relationship_post_response(array $parameters) {
   $request = $parameters['request'];


### PR DESCRIPTION
…type' request parameter.

This PR makes the documentation in the README and in the function-level comments for `islandora_rest_relationship_post_response()` more consistent with how the code in that function works. It only modified documentation and comments, not executable code.

As currently documented in the README's "Add A New Relationship" section ending a POST requests to islandora/rest/v1/object/{pid}/relationship to add a new relationship results in a 400 Bad Request with the error "Bad Request: Missing required fields type".

The current README documentation for "Add A New Relationship" describes the form-data fields 'datatype' (hence the 400 error above), but this field is not used in the code. The undocumented (in the README) field 'type' is used in the code, and is documented in the function-level doc for `islandora_rest_relationship_post_response()`. However, it is documented in the code as optional, but it is actually required. Also, the POST field 'literal' is not used in the function.