### PR TITLE
In api_auth, remove use of getallheaders() which doesn't work for PHP-FPM users

### DIFF
--- a/modules/islandora_rest_api_auth/islandora_rest_api_auth.module
+++ b/modules/islandora_rest_api_auth/islandora_rest_api_auth.module
@@ -41,10 +41,12 @@ function islandora_rest_api_auth_form_user_profile_form_alter(&$form, &$form_sta
  */
 function islandora_rest_api_auth_authenticate() {
   if (strpos(current_path(), 'islandora/rest/') === 0) {
-    $request_headers = getallheaders();
-    if (isset($request_headers['Authorization'])) {
+    if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
+      $authheader = $_SERVER['HTTP_AUTHORIZATION'];
+    }
+    if (isset($authheader)) {
       module_load_include('inc', 'islandora_rest_api_auth', 'includes/utilities');
-      list($username, $token) = explode(':', base64_decode(substr($request_headers['Authorization'], 6)));
+      list($username, $token) = explode(':', base64_decode(substr($authheader, 6)));
       if (islandora_rest_api_auth_authenticate_token($username, $token)) {
         islandora_rest_api_auth_login($username);
       }


### PR DESCRIPTION
@jordandukart - Some of us have to be pains and use PHP-FPM and Nginx.  getallheaders() doesn't fly in that environment. There have been a few cases of it showing up and getting squashed for this reason in the main Islandora code.

If someone who *is* running normal mod_php/Apache could verify this change, I'd appreciate it.