### PR TITLE
Replace ~slsh~ in query to work around path splitting

### DIFF
--- a/includes/solr.inc
+++ b/includes/solr.inc
@@ -19,7 +19,10 @@
  *   The un-encoded response containing the generated SOLR results.
  */
 function islandora_rest_solr_get_response(array $parameters) {
-  $query = $parameters['path']['query'];
+  module_load_include('inc', 'islandora_solr', 'includes/utilities');
+
+  // XXX: Replace '~slsh~' in query with '/' to get around path splitting.
+  $query = islandora_solr_restore_slashes($parameters['path']['query']);
   $request = $parameters['request'];
 
   $path_parts = parse_url(variable_get('islandora_solr_url', 'localhost:8080/solr'));


### PR DESCRIPTION
The issue:

The following request throws an 'invalid solr query' error, when really there's nothing wrong with it:
```
/rest/v1/solr/RELS_EXT_hasModel_uri_ms:"info:fedora/islandora:bookCModel"
```

The cause of the error is that the query is being split on the forward slash, so let's implement a workaround.

If this does get merged, I will open another PR to update the README.