### PR TITLE
Add namespace restriction check

### DIFF
--- a/includes/solr.inc
+++ b/includes/solr.inc
@@ -49,10 +49,10 @@ function islandora_rest_solr_get_response(array $parameters) {
     }
   }
 
-  $namespace_restriction = variable_get('islandora_namespace_restriction_enforced', FALSE);
-  if ($namespace_restriction == TRUE) {
-    $allowed_namespaces = trim(variable_get('islandora_pids_allowed', 'default: demo: changeme: ilives: islandora-book: books: newspapers: '));
-    $namespaces = preg_split('/[: |\s]/', $allowed_namespaces);
+  $namespace_restriction = variable_get('islandora_solr_namespace_restriction', FALSE);
+  if (!empty($namespace_restriction)) {
+    $allowed_namespaces = trim($namespace_restriction);
+    $namespaces = preg_split('/[, |\s]/', $allowed_namespaces);
     $namespace_array = array();
     foreach (array_filter($namespaces) as $namespace) {
       $namespace_array[] = "PID:$namespace\:*";

--- a/includes/solr.inc
+++ b/includes/solr.inc
@@ -48,6 +48,18 @@ function islandora_rest_solr_get_response(array $parameters) {
       $request['fq'] = $xacml_fq;
     }
   }
+
+  $namespace_restriction = variable_get('islandora_namespace_restriction_enforced', FALSE);
+  if ($namespace_restriction == TRUE) {
+    $allowed_namespaces = trim(variable_get('islandora_pids_allowed', 'default: demo: changeme: ilives: islandora-book: books: newspapers: '));
+    $namespaces = preg_split('/[: |\s]/', $allowed_namespaces);
+    $namespace_array = array();
+    foreach (array_filter($namespaces) as $namespace) {
+      $namespace_array[] = "PID:$namespace\:*";
+    }
+      $request['fq'] = implode(' OR ', $namespace_array);
+  }
+
   // Query is executed. Errors are caught and sent through to the response.
   $offset = isset($request['start']) ? (int) $request['start'] : 0;
   $limit = isset($request['rows']) ? (int) $request['rows'] : variable_get('islandora_solr_num_of_results', 20);

--- a/includes/solr.inc
+++ b/includes/solr.inc
@@ -57,7 +57,12 @@ function islandora_rest_solr_get_response(array $parameters) {
     foreach (array_filter($namespaces) as $namespace) {
       $namespace_array[] = "PID:$namespace\:*";
     }
+    if (is_array($request['fq'])) {
+      $request['fq'][] = implode(' OR ', $namespace_array);
+    }
+    else {
       $request['fq'] = implode(' OR ', $namespace_array);
+    }
   }
 
   // Query is executed. Errors are caught and sent through to the response.


### PR DESCRIPTION
Addresses issue #32 - adds a namespace restriction check and filter to `solr.inc`.

Test from the browser:
- In branch 7.x, `[site]/islandora/rest/v1/solr/dc.title:*` will get you a list of objects. Search (ctrl+f) for a PID e.g. `grunt:`
- Enable namespace restrictions and restrict the namespace you searched for
- Refresh your API call page and you'll see nothing's changed
- Check out this branch and refresh again
- Objects with the restricted namespace will not appear

This specifically limits namespaces when getting Solr results. I don't expect it will affect the other types of calls (e.g. deleting objects, creating objects, etc.).
